### PR TITLE
Fix experimental API usage

### DIFF
--- a/ui/Device_List.py
+++ b/ui/Device_List.py
@@ -342,5 +342,5 @@ if auto_refresh:
     # Auto-refresh
     if 'page_auto_refresh' in st.session_state and st.session_state['page_auto_refresh']:
         time.sleep(2)
-        st.experimental_rerun()
+        st.rerun()
 

--- a/ui/consent.py
+++ b/ui/consent.py
@@ -30,7 +30,7 @@ def show_overall_risks():
     consent = st.button('I accept the risks.', type='primary')
     if consent:
         config.set('has_consented_to_overall_risks', True)
-        st.experimental_rerun()
+        st.rerun()
 
     # Show a secondary button to reject the consent and quit
     reject = st.button('I do not accept the risks. I would like to quit IoT Inspector.', type='secondary')

--- a/ui/pages/1_Overview.py
+++ b/ui/pages/1_Overview.py
@@ -365,6 +365,6 @@ main()
 # Auto-refresh
 if 'page_auto_refresh' in st.session_state and st.session_state['page_auto_refresh']:
     time.sleep(4)
-    st.experimental_rerun()
+    st.rerun()
 
 

--- a/ui/pages/2_Device_Details.py
+++ b/ui/pages/2_Device_Details.py
@@ -400,9 +400,9 @@ pre_selected_index = 0
 default_option = '(Select a device below)'
 device_list = [default_option] + get_device_list()
 
-query_params = st.experimental_get_query_params()
+query_params = st.get_query_params()
 if 'mac_addr' in query_params:
-    mac_addr = query_params['mac_addr'][0]
+    mac_addr = query_params['mac_addr']
     for (ix, device_description) in enumerate(device_list):
         if mac_addr in device_description:
             pre_selected_index = ix
@@ -429,6 +429,6 @@ with st.empty():
 # Auto-refresh
 if 'page_auto_refresh' in st.session_state and st.session_state['page_auto_refresh']:
     time.sleep(4)
-    st.experimental_rerun()
+    st.rerun()
 
 


### PR DESCRIPTION
st.experimental_rerun() has been renamed to st.rerun() st.experimental_get_query_params() is now st.get_query_params(), and now returns a dictionary with string values as opposed to a list of strings